### PR TITLE
Add cron to schedule GitHub workflows to run daily

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   build-and-deploy:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 [<img src="https://raw.githubusercontent.com/theia-ide/security-audit/master/assets/gh-pages.png" alt="github pages" width="150px"/>](https://theia-ide.github.io/security-audit/)
 
-[<img src="https://api.travis-ci.com/theia-ide/security-audit.svg?branch=master" alt="travis status"/>](https://travis-ci.com/theia-ide/security-audit/builds)
-
+[![Build](https://github.com/theia-ide/security-audit/workflows/Build%20and%20Deploy%20GitHub%20Page/badge.svg?branch=master)](https://github.com/theia-ide/security-audit/actions)
 </div>
 
 


### PR DESCRIPTION
+ Add cron to schedule GitHub workflows to run daily.
+ Update build status badge.

Signed-off-by: Duc Nguyen <duc.a.nguyen@ericsson.com>